### PR TITLE
fix(tags): Missing logs tags

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/logs_that_burn.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/logs_that_burn.json
@@ -1,4 +1,5 @@
 {
+  "replace": false,
   "values": [
     "#bloomingnature:logs"
   ]

--- a/common/src/main/resources/data/minecraft/tags/blocks/planks.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/planks.json
@@ -1,4 +1,5 @@
 {
+  "replace": false,
   "values": [
     "bloomingnature:fir_planks",
     "bloomingnature:baobab_planks",
@@ -12,6 +13,3 @@
     "bloomingnature:cactus_planks"
   ]
 }
-
-
-

--- a/common/src/main/resources/data/minecraft/tags/items/logs.json
+++ b/common/src/main/resources/data/minecraft/tags/items/logs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#bloomingnature:logs"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/items/logs_that_burn.json
+++ b/common/src/main/resources/data/minecraft/tags/items/logs_that_burn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#bloomingnature:logs"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/items/planks.json
+++ b/common/src/main/resources/data/minecraft/tags/items/planks.json
@@ -1,4 +1,5 @@
 {
+  "replace": false,
   "values": [
     "bloomingnature:fir_planks",
     "bloomingnature:baobab_planks",
@@ -12,6 +13,3 @@
     "bloomingnature:cactus_planks"
   ]
 }
-
-
-


### PR DESCRIPTION
Added logs (items) to #minecraft:logs and #minecraft:logs_that_burn (Block tag already existed, but not item)
Added replace:false to #minecraft:logs_that_burn tag additions